### PR TITLE
rpi-u-boot-scr.bbappend: fixed conditional include of boot.cmd.in.

### DIFF
--- a/meta-rauc-raspberrypi/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bbappend
+++ b/meta-rauc-raspberrypi/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bbappend
@@ -1,5 +1,4 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
-
 inherit rauc-integration
 
+FILESEXTRAPATHS_prepend-rauc-integration := "${THISDIR}/files:"
 SRC_URI_append_rauc-integration = " file://boot.cmd.in"


### PR DESCRIPTION
To my surprise `FILESEXTRAPATHS` was leaking custom `boot.cmd.in` anyway. Tested with rpi4, now it's working as expected.