### PR TITLE
rpi-u-boot-scr.bbappend: fixed override typo.

### DIFF
--- a/meta-rauc-raspberrypi/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bbappend
+++ b/meta-rauc-raspberrypi/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bbappend
@@ -1,4 +1,4 @@
 inherit rauc-integration
 
-FILESEXTRAPATHS_prepend-rauc-integration := "${THISDIR}/files:"
+FILESEXTRAPATHS_prepend_rauc-integration := "${THISDIR}/files:"
 SRC_URI_append_rauc-integration = " file://boot.cmd.in"


### PR DESCRIPTION
Signed-off-by: Bartłomiej Burdukiewicz <bartlomiej.burdukiewicz@gmail.com>