### PR TITLE
Sunxi - Clean up compatibility inconsistency 

### DIFF
--- a/meta-rauc-sunxi/recipes-core/bundles/update-bundle.bb
+++ b/meta-rauc-sunxi/recipes-core/bundles/update-bundle.bb
@@ -2,11 +2,11 @@ DESCRIPTION = "RAUC bundle generator"
 
 inherit bundle
 
-RAUC_BUNDLE_COMPATIBLE = "OrangePi"
+RAUC_BUNDLE_COMPATIBLE = "Sunxi"
 RAUC_BUNDLE_VERSION = "v20200703"
 RAUC_BUNDLE_DESCRIPTION = "RAUC Demo Bundle"
 RAUC_BUNDLE_SLOTS = "rootfs" 
-RAUC_SLOT_rootfs = "core-image-full-cmdline"
+RAUC_SLOT_rootfs = "core-image-minimal"
 RAUC_SLOT_rootfs[fstype] = "ext4"
 
 RAUC_KEY_FILE = "${THISDIR}/files/development-1.key.pem"

--- a/meta-rauc-sunxi/recipes-core/rauc/files/system.conf
+++ b/meta-rauc-sunxi/recipes-core/rauc/files/system.conf
@@ -1,5 +1,5 @@
 [system]
-compatible=OrangePiZero
+compatible=Sunxi
 bootloader=uboot
 
 [keyring]


### PR DESCRIPTION
A small bit of cleanup. 

Realized that the `RAUC_BUNDLE_COMPATIBLE` and system.conf `compatible` values were different which was causing apparent compatibility issues when there were none. At the very least, they need to be consistent and probably should be something different than "OrangePi" since this compatibility should, in theory, work for more sunxi devices. 

Also changed RAUC_SLOT_rootfs to `core-image-minimal` which is likely what it should be as its default. 